### PR TITLE
🐛 修正(install.rb): unzipコマンドにオプション-oを追加

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -14,7 +14,7 @@ bash "expand vault-#{node['vault']['version']}" do
   not_if "test -f #{node['vault']['lib_path']}/bin/vault-#{node['vault']['version']}"
   code <<-CODE
     cd "#{cache_path}"
-    unzip vault-#{node['vault']['version']}.zip
+    unzip -o vault-#{node['vault']['version']}.zip
     chmod +x vault
     mv vault #{node['vault']['lib_path']}/bin/vault-#{node['vault']['version']}
   CODE


### PR DESCRIPTION
unzipコマンドにオプション-oを追加しました。これにより、既存のファイルを上書きすることなく、vault-#{node['vault']['version']}.zipを展開できます。